### PR TITLE
Fix CLI: synchronize switch name with internal parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,50 +93,50 @@ Command line options are:
   --n-samples-per-label N_SAMPLES_PER_LABEL
                         samples per label (default: 16)
   --n-true-features N_TRUE_FEATURES
-                        number of underlying true hidden features, they are 
+                        number of underlying true hidden features, they are
                         meant to be useful features (default: 40)
   --n-fake-features N_FAKE_FEATURES
-                        number of underlying fake hidden features, they are 
+                        number of underlying fake hidden features, they are
                         meant to be fixed random noise (default: 0)
   --min-usefulness MIN_USEFULNESS
-                        minimum usefulness of true hidden features 
+                        minimum usefulness of true hidden features
                         (default: 0.5)
   --max-usefulness MAX_USEFULNESS
-                        maximum usefulness of true hidden features 
+                        maximum usefulness of true hidden features
                         (default: 0.95)
   --usefulness-scheme {linear,exponential,longtailed}
-                        distribution of usefulness in true hidden features 
+                        distribution of usefulness in true hidden features
                         (default: linear)
   --tail-power TAIL_POWER
-                        exponent for longtailed usefulness-scheme 
+                        exponent for longtailed usefulness-scheme
                         (default: 1.5)
   --location-distribution {norm,uniform}
-                        distribution type of the characteristic trait of 
-                        labels, i.e., the envelop of locations for true 
+                        distribution type of the characteristic trait of
+                        labels, i.e., the envelop of locations for true
                         features (default: norm)
   --sampling-distribution {norm,uniform}
                         distribution type of the uncertainty of reproduction,
-                        i.e., the noise for different samples from the same 
+                        i.e., the noise for different samples from the same
                         label in hidden features (default: norm)
   --location-ordering-extent LOCATION_ORDERING_EXTENT
-                        keep segments of locations of given block size 
-                        together in each feature independently, use -1 to use 
+                        keep segments of locations of given block size
+                        together in each feature independently, use -1 to use
                         exactly the same location order (default: 0)
-  --average-shared-locations AVERAGE_SHARED_LOCATIONS
-                        make locations shared by multiple labels in each 
-                        feature independently, use 0 to make all locations 
+  --location-sharing-extent LOCATION_SHARING_EXTENT
+                        make locations shared by multiple labels in each
+                        feature independently, use 0 to make all locations
                         unique (default: 0)
   --polynomial          use polynomial mixing of features (default: False)
   --n-features-out N_FEATURES_OUT
-                        number of measured features to be simulated 
+                        number of measured features to be simulated
                         (default: 10000)
   --blending-mode {linear,logarithmic}
                         how to simulate measured features (default: linear)
   --min-count MIN_COUNT
-                        minimum number of hidden features taking part in one 
+                        minimum number of hidden features taking part in one
                         specific output feature (default: 5)
   --max-count MAX_COUNT
-                        maximum number of hidden features taking part in one 
+                        maximum number of hidden features taking part in one
                         specific output feature (default: 10)
   --random-state RANDOM_STATE
                         integer random seed (default: 137)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="biometricblender",
-    version="1.0.0",
+    version="1.0.1",
     author="Marcell Stippinger",
     author_email="stippingerm.prog@gmail.com",
     description=("BiometricBlender: Ultra-high dimensional, multi-class "

--- a/src/biometric_blender/__main__.py
+++ b/src/biometric_blender/__main__.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
                         'together in each feature independently, use -1 to '
                         'use exactly the same location order',
                    default=0, type=int)
-    p.add_argument('--average-shared-locations',
+    p.add_argument('--location-sharing-extent',
                    help='make locations shared by multiple labels in each '
                         'feature independently, use 0 to make all locations '
                         'unique',


### PR DESCRIPTION
The keyword argument `average_shared_locations` was renamed to `location_sharing_extent`, but the CLI was not synched.